### PR TITLE
fix: prevent long CJK description overflow in RepoTile

### DIFF
--- a/frontend/src/components/RepoTile.tsx
+++ b/frontend/src/components/RepoTile.tsx
@@ -25,7 +25,7 @@ export const RepoTile = ({ repo }: { repo: Repo }) => {
             {repo.name}
           </a>
 
-          <p className="text-muted-foreground line-clamp-3 text-sm">
+          <p className="text-muted-foreground line-clamp-3 break-all text-sm">
             {repo.description || 'No description'}
           </p>
         </div>


### PR DESCRIPTION
## Summary
  - Add `break-all` class to the description paragraph in `RepoTile.tsx` to force line breaks between any characters, fixing overflow for continuous CJK text

  ## Problem
  The repo [Dujltqzv/Some-Many-Books](https://github.com/Dujltqzv/Some-Many-Books) has a description with thousands of Chinese characters and no spaces. This causes the text to overflow the card layout on the listing page.

  ## Test plan
  - Verify on `?time=weekly` that the repo with a long Chinese description is properly clamped to 3 lines
  - Confirm other repos with English/emoji descriptions still render correctly